### PR TITLE
Fix: Home needs to be concat as a dir

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -60,7 +60,7 @@ This path gets added to the PATH variable and the exec-path list.")
   (mapcan
    'chruby-collect-rubies
    (list "/opt/rubies/"
-	 (concat (getenv "HOME") ".rubies")
+	 (concat (file-name-as-directory (getenv "HOME")) ".rubies")
 	 (getenv "RUBIES_DIR")
 	 "~/opt/rubies")))
 


### PR DESCRIPTION
When trying to concat the HOME, we need to make sure it's a directory, otherwise the wrong path will be created. (e.g. /users/name.rubies)
