### PR TITLE
Omit STDERR from return value of chruby-query-version.

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -145,7 +145,7 @@
 ruby version, and the gem path"
   (split-string
    (shell-command-to-string
-    (concat ruby-bin "/ruby -rubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir.inspect)].join(%[##])'")) "##"))
+    (concat ruby-bin "/ruby -rubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir.inspect)].join(%[##])' 2>/dev/null")) "##"))
 
 (defun chruby-util-basename (path)
   (file-name-nondirectory (directory-file-name path)))


### PR DESCRIPTION
Using a redirect to /dev/null, avoid capturing STDERR in the return
value of chruby-query-version. This addresses a situation where warning
output from Rubygems gets included in the returned values.

It is possible there is a better way to do this; this was just the first thing that sprang to mind.