### PR TITLE
Avoid extra pair of quotes around gem path

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -147,7 +147,7 @@
 ruby version, and the gem path"
   (split-string
    (shell-command-to-string
-    (concat ruby-bin "/ruby -rubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir.inspect)].join(%[##])' 2>/dev/null")) "##"))
+    (concat ruby-bin "/ruby -rubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir)].join(%[##])' 2>/dev/null")) "##"))
 
 (defun chruby-util-basename (path)
   (file-name-nondirectory (directory-file-name path)))


### PR DESCRIPTION
Due to the call to inspect, previously an extra pair of quotes was added
around the second element of GEM_PATH, resulting in something like this
in the environment:

GEM_PATH=/home/tils/.gem/ruby/2.3.3:"/home/tils/.rubies/ruby-2.3.3/lib/ruby/gems/2.3.0"

Which prevented rubygems to find gems that are located in the second
path (tested with Ruby 2.3.2 and gem 2.5.2).