### PR TITLE
Stop setting BUNDLE_PATH

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -105,11 +105,9 @@
   (if (and gemhome gempath)
       (progn
         (setenv "GEM_HOME" gemhome)
-        (setenv "GEM_PATH" gempath)
-        (setenv "BUNDLE_PATH" gemhome))
+        (setenv "GEM_PATH" gempath))
     (setenv "GEM_HOME" "")
-    (setenv "GEM_PATH" "")
-    (setenv "BUNDLE_PATH" "")))
+    (setenv "GEM_PATH" "")))
 
 ;;;###autoload
 (defun chruby (&optional name)


### PR DESCRIPTION
I didn't dig into why BUNDLE_PATH was being overridden, but I'm fairly confident
it shouldn't be. It appears to override the bundler configuration, breaking
things.

It's not uncommon for users to set `BUNDLE_PATH` in their `$HOME/.bundle/config`
to something like "vendor/bundle" in order to get their project gems installed
into a directory within the project. This is even encouraged by the bundler
docs.

Setting BUNDLE_PATH to the gem home in the env appears to break this. Bundler
commands run from within emacs are unable to find any of the gems that are
installed locally to my projects, I assume because they are searching in the
GEM_HOME instead of the project local path.