### PR TITLE
Update ruby require for rubygems

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -147,7 +147,7 @@
 ruby version, and the gem path"
   (split-string
    (shell-command-to-string
-    (concat ruby-bin "/ruby -rubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir)].join(%[##])' 2>/dev/null")) "##"))
+    (concat ruby-bin "/ruby -rrubygems -e 'print [(defined?(RUBY_ENGINE) ? RUBY_ENGINE : %[ruby]), (RUBY_VERSION), (Gem.default_dir)].join(%[##])' 2>/dev/null")) "##"))
 
 (defun chruby-util-basename (path)
   (file-name-nondirectory (directory-file-name path)))


### PR DESCRIPTION
Had an issue with ruby 2.5 not finding the gem bin directory.  Seems related to the `-rlibrary` option not being in the right format.  Switching to `-rrubygems` seems to fix the issue for me.  