### PR TITLE
Fix integration with eshell

### DIFF
--- a/chruby.el
+++ b/chruby.el
@@ -47,6 +47,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eshell)
 
 (defvar chruby-current-ruby-binary-path nil
   "reflects the path to the current 'ruby' executable.
@@ -98,7 +99,7 @@
       (setenv "PATH" (concat new-binaries-for-path ":" (getenv "PATH"))))
     (dolist (binary new-binaries)
       (add-to-list 'exec-path binary))
-    (setq eshell-path-env (getenv "PATH"))
+    (eshell-set-path (getenv "PATH"))
     (setq chruby-current-ruby-binary-path new-binaries)))
 
 (defun chruby-set-gemhome (gemhome gempath)


### PR DESCRIPTION
Hello

Problem: When I am in eshell and I change the ruby version with `chruby-use`, the ruby version does not change:

```
  ~ $ ruby --version
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  <M-x chruby-use, RET choose another version>
  ~ $ ruby --version
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
```
It seems the assignment to the buffer local variable `eshell-path-env` does not work. Moreover this one was deprecated in Emacs 29.1.

Solution: Use the `eshell-set-path` to set the eshell PATH and make sure this function is available by requiring the `eshell` package.

Regards